### PR TITLE
add rspec version and activemodel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ ruby '1.9.3'
 gem 'nokogiri'
 gem 'fakeweb'
 gem 'debugger'
+
+gem 'rspec', '2.14'
+gem 'activemodel'


### PR DESCRIPTION
I had problems running it because rspec 3.0.0 doesn't have `its`, `nested` format and it requires activemodel to work.
Sorry if I'm wrong, I'm a very beginner.
Cheers!
