### PR TITLE
Remove Ruby 1.9.3 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ to this assignment scattered throughout the handout:
 
 Nokogiri docs: http://nokogiri.org/
 
-Docs for Ruby libraries Net::HTTP, URI, CGI:  http://ruby-doc.org/stdlib-1.9.3
+Docs for Ruby libraries Net::HTTP, URI, CGI:  http://ruby-doc.org/
 
 # Background: The Oracle of Bacon
 


### PR DESCRIPTION
This assignment works with Ruby 2.2.2 and Ruby 2.2.3 (I think) so removing the 1.9.3 reference from the ruby docs link
