### PR TITLE
Clarify tests

### DIFF
--- a/spec/oracle_of_bacon_spec.rb
+++ b/spec/oracle_of_bacon_spec.rb
@@ -8,8 +8,8 @@ require 'rspec/collection_matchers'
 describe OracleOfBacon do
   before(:all) { FakeWeb.allow_net_connect = false }
   describe 'instance', :pending => true do
-    before(:each) { @orb = OracleOfBacon.new('fake_api_key') }
-    describe 'when new' do
+    before(:each) { @orb = OracleOfBacon.new('some_api_key') }
+    describe 'when neither From nor To is specified, defaults are used' do
       subject { @orb }
       it { should_not be_valid }
     end
@@ -38,24 +38,28 @@ describe OracleOfBacon do
       end
     end
   end
+
   describe 'parsing XML response', :pending => true do
     describe 'for unauthorized access/invalid API key' do
       subject { OracleOfBacon::Response.new(File.read 'spec/unauthorized_access.xml') }
       its(:type) { should == :error }
       its(:data) { should == 'Unauthorized access' }
     end
+
     describe 'for a normal match' do
       subject { OracleOfBacon::Response.new(File.read 'spec/graph_example.xml') }
       its(:type) { should == :graph }
       its(:data) { should == ['Carrie Fisher', 'Under the Rainbow (1981)',
                               'Chevy Chase', 'Doogal (2006)', 'Ian McKellen'] }
     end
+
     describe 'for a normal match (backup)' do
       subject { OracleOfBacon::Response.new(File.read 'spec/graph_example2.xml') }
       its(:type) { should == :graph }
       its(:data) { should == ["Ian McKellen", "Doogal (2006)", "Kevin Smith (I)",
                               "Fanboys (2009)", "Carrie Fisher"] }
     end
+
     describe 'for a spellcheck match' do
       subject { OracleOfBacon::Response.new(File.read 'spec/spellcheck_example.xml') }
       its(:type) { should == :spellcheck }
@@ -63,12 +67,14 @@ describe OracleOfBacon do
       its(:data) { should include('Anthony Perkins (I)') }
       its(:data) { should include('Anthony Parkin') }
     end
+
     describe 'for unknown response' do
       subject { OracleOfBacon::Response.new(File.read 'spec/unknown.xml') }
       its(:type) { should == :unknown }
       its(:data) { should match /unknown/i }
     end
   end
+
   describe 'constructing URI', :pending => true do
     subject do
       oob = OracleOfBacon.new('fake_key')
@@ -101,4 +107,3 @@ describe OracleOfBacon do
   end
 
 end
-      


### PR DESCRIPTION
Unclear why when new should not be valid especially when using fake_api_key string as api_key
Further review shows that it should not be valid because a person needs to specify a from or a to
as default values are the same and therefore not valid as per from_does_not_equal_to method.

Fixes #17 