### PR TITLE
Upgrade to Ruby 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'byebug'
 gem 'activemodel', '4.2.10'
 
 group :test do
-  gem 'fakeweb'
+  gem 'fakeweb', git: 'https://github.com/chrisk/fakeweb.git'
   gem 'rspec', '3.3.0'
   gem 'rspec-its'
   gem 'rspec-collection_matchers'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
-ruby '2.3.0'
+ruby '2.4.0'
 
 gem 'nokogiri'
 gem 'byebug'
-gem 'activemodel', '4.2.1'
+gem 'activemodel', '4.2.10'
 
 group :test do
   gem 'fakeweb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,61 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.2.10)
+      activesupport (= 4.2.10)
+      builder (~> 3.1)
+    activesupport (4.2.10)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    builder (3.2.3)
+    byebug (10.0.2)
+    concurrent-ruby (1.0.5)
+    diff-lcs (1.3)
+    fakeweb (1.3.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activemodel (= 4.2.10)
+  byebug
+  fakeweb
+  nokogiri
+  rspec (= 3.3.0)
+  rspec-collection_matchers
+  rspec-its
+
+RUBY VERSION
+   ruby 2.4.0p0
+
+BUNDLED WITH
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/chrisk/fakeweb.git
+  revision: 2b08c1ff2714ec13a12f3497d67fcefce95c2cbe
+  specs:
+    fakeweb (1.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -13,7 +19,6 @@ GEM
     byebug (10.0.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    fakeweb (1.3.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     mini_portile2 (2.3.0)
@@ -48,7 +53,7 @@ PLATFORMS
 DEPENDENCIES
   activemodel (= 4.2.10)
   byebug
-  fakeweb
+  fakeweb!
   nokogiri
   rspec (= 3.3.0)
   rspec-collection_matchers


### PR DESCRIPTION
upgrading to Ruby 2.4 and ActiveModel 4.2.10

Latest fakeweb gem does not work with Ruby 2.4. so we're now grabbing that from edge of Fakeweb repo